### PR TITLE
Update v1.0.0 to v2.0.0

### DIFF
--- a/src/initMemory.h
+++ b/src/initMemory.h
@@ -1,80 +1,34 @@
 #pragma once
+
 #include <Arduino.h>
 #include <FS.h>
 
+// Uncomment to enable serial debug
+// #define Debug_Serial_Memory
+
 /**
- * @brief A simple file-system helper for ESP32 (SPIFFS, LittleFS, SD).
- * @version 1.0.0
+ * @brief A lightweight FS helper class for ESP32 (SPIFFS, LittleFS, SD).
+ * @version 2.0.0
  * @author Milad Nikpendar
  */
-struct memory_t {
-  memory_t();
-
+class memoryAccess_t {
+public:
   /**
-   * @brief Initialize the FS instance (SPIFFS, LittleFS or SD).
-   * @param fs Pointer to an initialized fs::FS object.
+   * @brief Construct a new memoryAccess_t object and bind FS.
+   * @param initMemory pointer to SPIFFS, LittleFS or SD instance
    */
-  void init(fs::FS *fs);
+  memoryAccess_t(fs::FS *initMemory);
 
-  /**
-   * @brief List files and directories.
-   * @param dirname Root path to list.
-   * @param levels Depth of recursion.
-   * @return true on success, false otherwise.
-   */
-  bool listDir(const String &dirname, uint8_t levels);
-
-  /**
-   * @brief Create a directory.
-   * @param path Directory path to create.
-   * @return true on success.
-   */
-  bool createDir(const String &path);
-
-  /**
-   * @brief Remove a directory.
-   * @param path Directory path to remove.
-   * @return true on success.
-   */
-  bool removeDir(const String &path);
-
-  /**
-   * @brief Read the entire contents of a text file.
-   * @param path File path.
-   * @return File contents as String (or error message).
-   */
-  String read(const String &path);
-
-  /**
-   * @brief Write (overwrite) a text file.
-   * @param path File path.
-   * @param message Content to write.
-   * @return true on success.
-   */
-  bool write(const String &path, const String &message);
-
-  /**
-   * @brief Append to a text file.
-   * @param path File path.
-   * @param message Content to append.
-   * @return true on success.
-   */
-  bool append(const String &path, const String &message);
-
-  /**
-   * @brief Rename or move a file.
-   * @param path1 Old path.
-   * @param path2 New path.
-   * @return true on success.
-   */
-  bool rename(const String &path1, const String &path2);
-
-  /**
-   * @brief Delete a file.
-   * @param path File path.
-   * @return true on success.
-   */
-  bool remove(const String &path);
+  bool type(uint8_t cardType);
+  bool listDir(const char *dirname, uint8_t levels);
+  bool createDir(const char *path);
+  bool removeDir(const char *path);
+  String read(const char *path);
+  bool write(const char *path, const char *message);
+  bool append(const char *path, const char *message);
+  bool rename(const char *path1, const char *path2);
+  bool remove(const char *path);
+  void testIO(const char *path);
 
 private:
   fs::FS *typeMemory;


### PR DESCRIPTION
## 🚀 What’s Changed in v2.0.0

This PR upgrades **initMemory** from 1.x to **2.0.0**, introducing a redesigned API, SD-card type detection, I/O benchmarking, and internal cleanup:

### 🎉 New Features
- **`memoryAccess_t` class**  
  - Constructor now binds an `fs::FS*` instance:  
    ```cpp
    memoryAccess_t storage(&SPIFFS);
    ```
- **SD-card type detection** via `type(uint8_t cardType)` (supports MMC, SDSC, SDHC)  
- **I/O benchmark** method `testIO(const char* path)` to measure read/write throughput  
- Path arguments switched from `String` → **`const char*`** for lower RAM overhead  
- Renamed debug macro to **`Debug_Serial_Memory`** for consistency  

### ✨ Internal Improvements
- Moved the `fs::FS* typeMemory` pointer into the class’s **private** section  
- Split implementation into `.h` (interface) and `.cpp` (implementation)  
- Standardized Serial debug messages using `Serial.printf()`  

### 🔥 Breaking Changes & Migration
1. **Initialization**  
   - **Before (v1.x)**  
     ```cpp
     memory_t mem;
     mem.init(&SPIFFS);
     ```
   - **Now (v2.x)**  
     ```cpp
     memoryAccess_t mem(&SPIFFS);
     ```
2. **API Signatures**  
   - All methods now take C-style strings (`const char*`) instead of `String`.  
   - Debug macro changed:
     ```diff
     - #define MemorydebugSerial
     + #define Debug_Serial_Memory
     ```

> **Migration tip:** Update your includes and constructor call, then replace all `listDir("…")`, `read("…")`, etc., to use C-strings.

### ✅ Testing
- Verified on **ESP32** with both **SPIFFS** and **SD card** setups.  
- Ran the new `testIO()` on SD to confirm read/write speeds.  
- Existing examples updated under `examples/ESP32_Memory_Explorer`.

### 📝 Other Changes
- Bumped `version=2.0.0` in **`library.properties`**  
- Updated `README.md` code samples and **Version:** badge  
- Refreshed `CHANGELOG.md` with full v2.0.0 notes  

---